### PR TITLE
z-index fixed; zoom on hover for cards

### DIFF
--- a/src/components/pages/Game.js
+++ b/src/components/pages/Game.js
@@ -102,7 +102,7 @@ function Game() {
     //animation (for an incorrect answer). None of these functions are to be called for a mouse click on the div but not on one of
     //the cards (should the value of e.target.id === ""). This prevents inappropriate activation of functions meant solely to be
     //called for a card click.
-    return( <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2" onClick={(e) => {
+    return( <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4" onClick={(e) => {
       if(e.target.id === "") {
         return;
       };
@@ -137,8 +137,10 @@ function Game() {
     <div>
       
       {/* header formatting: flexbox with elements spaced evenly; header position is fixed and does not scroll up or down. For 
-      smaller screens sizes text elements are displayed in column; for large screens it is displayed in a row */}
-      <header className="text-center lg:flex text-white bg-purple-900 py-6 text-3xl fixed w-screen lg:justify-evenly shadow-2xl">
+      smaller screen sizes text elements are displayed in column; for large screens they are displayed in a row. z-index is set higher
+      than for the card display in the main element below to prevent the cards appearing over the header when the shake animation
+      is active. */}
+      <header className="z-10 text-center lg:flex text-white bg-purple-900 py-6 text-3xl fixed w-screen lg:justify-evenly shadow-2xl">
         <h1 className="ml-2 text-5xl lg:text-3xl font-extrabold">Clicky Game</h1>
         
         {/* formatting for instruction text, which also doubles to let the user know whether a click is correct or incorrect.
@@ -157,9 +159,11 @@ function Game() {
         <h2 className="text-center text-2xl font-bold">Click on an image to earn points, but don't click on any more than once!</h2>
       </article>
       
-      {/* card display, centered in a flex box the value for cardMainMotion is changed to activate the shake animation when an 
-      incorrect answer is given. The GemDisplay function is activated to reshuffle the cards immediately upon click */}
-      <main className="flex justify-center">
+      {/* card display, centered in a flex box; the value for cardMainMotion is changed to activate the shake animation when an 
+      incorrect answer is given. The GemDisplay function is activated to reshuffle the cards immediately upon click. The z-index
+      for this element is set lower than for the header above to prevent the cards appearing over the header when the shake
+      animation is activated. */}
+      <main className="z-0 flex justify-center py-5">
         <div className={cardState.cardMainMotion + cardFormat}>
         {cardState.cardShuffle}
         </div>

--- a/src/components/pages/GemCard.js
+++ b/src/components/pages/GemCard.js
@@ -1,14 +1,15 @@
 import React from "react";
 
-//Generates a simple card to be used in conjunction with gems.json and the map method in Game.js; id is set for click events 
+//Generates a simple card to be used in conjunction with gems.json and the map method in Game.js; id is set for click events, 
 //title information for alt and location to provide an address for stored images in the public folder. className formats the 
-//image display within a slate colored frame and activates a cursor pointer upon hover
+//image display within a slate colored frame; there is also a shadow effect. A cursor pointer, further shadow effects and a  
+//zoom animation are activated upon hover.
 function GemCard(props) {
     return ( 
       <article> 
         <div id={props.id}>
             <img id={props.id} alt={props.title} src={props.location} 
-            className="object-cover w-40 h-40 border-4 border-slate-500 cursor-pointer"></img>
+            className="shadow-black shadow-lg hover:shadow-2xl hover:shadow-black hover:animate-zoom object-cover w-40 h-40 border-4 border-slate-500 cursor-pointer"></img>
         </div>
       </article>
     );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -176,6 +176,12 @@ module.exports = {
           '2.5%, 12.5%, 22.5%, 32.5%, 42.5%, 52.5%, 62.5%, 72.5%, 82.5%, 92.5%': {color: 'red'},
           '5%, 15%, 25%, 35%, 45%, 55%, 65%, 75%, 85%, 95%': {color: 'blue'},
           '7.5%, 17.5%, 27.5%, 37.5%, 47.5%, 57.5%, 67.5%, 77.5%, 87.5%, 97.5%': {color: 'green'},
+        },
+        //This effect marginally increases the size of the element to which it is applied and is used upon hover for all the game
+        //cards. The code for this effect is derived from an example from "W3 Schools": "How TO - Zoom on Hover", W3 Schools, last
+        //viewed: 15 May 2023: https://www.w3schools.com/howto/howto_css_zoom_hover.asp
+        zoom: {
+          '0%, 100%': {transform: 'scale(1.1)'},
         }
       },
       animation: {
@@ -189,6 +195,7 @@ module.exports = {
         textFall: 'textFall 5s infinite',
         colorWave: 'colorWave 60s infinite',
         textGrow2: 'textGrow2 5s 1',
+        zoom: 'zoom .2s infinite'
       },
       
     },


### PR DESCRIPTION
z-index for header set higher than for main (to prevent main appearing on top of header during shake animation)
zoom animation added to tailwind.config.js
zoom animation activated upon hover for cards; shadows added to cards
comments updated